### PR TITLE
Add the loading screen

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -7,6 +7,7 @@ import OrderContext from "./contexts/OrderContext";
 import { OrderTypes } from "./types/order";
 
 import "./App.css";
+import CircleLoader from "./components/CircleLoader";
 
 const App: React.FC = () => {
   const [jobs, setJobs] = useState([]);
@@ -37,12 +38,12 @@ const App: React.FC = () => {
         }}
       >
         <Nav />
-        {!!JobList.length && (
+        {(!!JobList.length && (
           <div data-testid="app-jobs" className="App-jobs">
             <OrderBy />
             {JobList}
           </div>
-        )}
+        )) || <CircleLoader loadingText="Loading" fullHeightWithNav />}
       </OrderContext.Provider>
     </div>
   );

--- a/src/components/CircleLoader/index.css
+++ b/src/components/CircleLoader/index.css
@@ -1,0 +1,34 @@
+.circle-loader {
+  display: flex;
+  flex-flow: column nowrap;
+  justify-content: center;
+  align-items: center;
+  gap: 0.25rem;
+}
+
+.circle-loader--full-height-with-nav {
+  height: calc(100vh - 95px);
+}
+
+.circle-loader__spinner {
+  border: 8px solid #00c;
+  border-top-color: #fff;
+  border-radius: 50%;
+  width: 50px;
+  height: 50px;
+  animation: spin 2s linear infinite;
+}
+
+@keyframes spin {
+  0% {
+    transform: rotate(0deg);
+  }
+  100% {
+    transform: rotate(360deg);
+  }
+}
+
+.circle-loader__text {
+  color: #00c;
+  font-size: 1.2rem;
+}

--- a/src/components/CircleLoader/index.tsx
+++ b/src/components/CircleLoader/index.tsx
@@ -1,0 +1,25 @@
+import React, { FC } from "react";
+
+import CircleLoaderProps from "../../types/circleLoader";
+import "./index.css";
+
+const CircleLoader: FC<CircleLoaderProps> = ({
+  loadingText,
+  fullHeightWithNav,
+}) => {
+  return (
+    <div
+      className={
+        "circle-loader" +
+        (!!fullHeightWithNav ? " circle-loader--full-height-with-nav" : "")
+      }
+    >
+      <div className="circle-loader__spinner"></div>
+      {!!loadingText && (
+        <div className="circle-loader__text">{loadingText}</div>
+      )}
+    </div>
+  );
+};
+
+export default CircleLoader;

--- a/src/types/circleLoader.ts
+++ b/src/types/circleLoader.ts
@@ -1,0 +1,6 @@
+type CircleLoaderDefinition = {
+  loadingText?: string;
+  fullHeightWithNav?: boolean;
+};
+
+export default CircleLoaderDefinition;


### PR DESCRIPTION
Adding the loading screen will make the wait less imcomprehensible for
the users.

Following the current code design and convention, the solution is
implemented:

- Create the `CircleLoader` component to style the loading screen
- Create `circleLoader` type as a type properties of the `CircleLoader`
  component
- Add the `CircleLoader` component to the `App.tsx` to display the
  loading screen if the jobs are not loaded

Things could be improvement:

- Write test for the `CircleLoader` component
- Add animation when unmounting the `CircleLoader`